### PR TITLE
Update README to always link to latest NET 8 Desktop Runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Version 1.3
 > [!NOTE]
 > To use SA Mod Manager, you must have:
 > * Windows 7 or later
-> * [.NET Desktop Runtime 8.0](https://dotnet.microsoft.com/fr-fr/download/dotnet/thank-you/runtime-desktop-8.0.10-windows-x64-installer)
+> * [.NET 8.0 x64 Desktop Runtime](https://aka.ms/dotnet-core-applaunch?missing_runtime=true&arch=x64&apphost_version=8.0.0&gui=true)
 
 > [!IMPORTANT]
 > To use the Mod Loader, you must have:


### PR DESCRIPTION
Using `aka.ms/dotnet-core-applaunch` will always result in linking to the latest patch version of the Desktop Runtime (8.0.21 at time of writing), instead of hardlinking to the older 8.0.10.
Additionally this will use the user's native language instead of FR



* Reorder NET 8.0 placement to match Microsoft
* Explicitly mention x64