### PR TITLE
Fix Publishing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
     - name: Checkout Code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0
         submodules: 'recursive'
@@ -35,13 +35,13 @@ jobs:
       run: npm install -g auto-changelog
 
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: '8.0.x' 
 
     - name: Publish 64-bit WPF application
       working-directory: ${{env.GITHUB_WORKSPACE}}
-      run: dotnet publish -p:PublishSingleFile=true -r win-x64 -c Release --self-contained false
+      run: dotnet publish win-x64 -c Release
       
     - name: CleanUp Misc Files (64-bit)
       working-directory: ${{github.workspace}}\bin\Release\net8.0-windows7.0\win-x64\publish
@@ -49,7 +49,7 @@ jobs:
       
     - name: Publish 32-bit WPF application
       working-directory: ${{env.GITHUB_WORKSPACE}}
-      run: dotnet publish -p:PublishSingleFile=true -r win-x86 -c Release --self-contained false
+      run: dotnet publish -r win-x86 -c Release
       
     - name: CleanUp Misc Files (32-bit)
       working-directory: ${{github.workspace}}\bin\Release\net8.0-windows7.0\win-x86\publish
@@ -61,7 +61,7 @@ jobs:
         auto-changelog --sort-commits date --hide-credit --template changelog-template.hbs --commit-limit 30 --starting-version "$env:RELEASE_TAG" --output "$env:PUBLISH_CHANGELOG_PATH"
       
     - name: Archive 64-bit
-      uses: thedoctor0/zip-release@0.7.5
+      uses: thedoctor0/zip-release@0.7.6
       with:
         type: 'zip'
         filename: 'release_x64.zip'
@@ -69,7 +69,7 @@ jobs:
         exclusions: '*.git* /*node_modules/* .editorconfig'
         
     - name: Archive 32-bit
-      uses: thedoctor0/zip-release@0.7.5
+      uses: thedoctor0/zip-release@0.7.6
       with:
         type: 'zip'
         filename: 'release_x86.zip'
@@ -78,7 +78,7 @@ jobs:
         
       
     - name: Create Release
-      uses: softprops/action-gh-release@v0.1.15
+      uses: softprops/action-gh-release@v2
       with:
         body_path: ${{ env.PUBLISH_CHANGELOG_PATH }}
         files: |

--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           submodules: 'recursive'
@@ -33,13 +33,13 @@ jobs:
         run: echo ${{github.sha}} > SA-Mod-Manager/Resources/Version.txt
 
       - name: Setup .NET Core
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '8.0.x' 
 
       - name: Publish 64-bit WPF application
         working-directory: ${{env.GITHUB_WORKSPACE}}
-        run: dotnet publish -p:PublishSingleFile=true -r win-x64 -c ${{ matrix.configuration }} --self-contained false
+        run: dotnet publish -r win-x64 -c ${{ matrix.configuration }}
 
       - name: CleanUp Misc Files (64-bit)
         working-directory: ${{github.workspace}}\bin\${{ matrix.configuration }}\net8.0-windows7.0\win-x64\publish
@@ -47,7 +47,7 @@ jobs:
 
       - name: Publish 32-bit WPF application
         working-directory: ${{env.GITHUB_WORKSPACE}}
-        run: dotnet publish -p:PublishSingleFile=true -r win-x86 -c ${{ matrix.configuration }} --self-contained false
+        run: dotnet publish -r win-x86 -c ${{ matrix.configuration }}
 
       - name: CleanUp Misc Files (32-bit)
         working-directory: ${{github.workspace}}\bin\${{ matrix.configuration }}\net8.0-windows7.0\win-x86\publish
@@ -55,13 +55,13 @@ jobs:
 
       # Step to upload the dev build artifact
       - name: Upload 64-bit Build Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: SAModManager_x64_${{ matrix.configuration }}
           path: bin/${{ matrix.configuration }}/net8.0-windows7.0/win-x64/publish
 
       - name: Upload 32-bit Build Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: SAModManager_x86_${{ matrix.configuration }}
           path: bin/${{ matrix.configuration }}/net8.0-windows7.0/win-x86/publish

--- a/SA-Mod-Manager/SAModManager.csproj
+++ b/SA-Mod-Manager/SAModManager.csproj
@@ -7,6 +7,10 @@
 		<UseWPF>true</UseWPF>
 		<UseWindowsForms>true</UseWindowsForms>
 		<ApplicationIcon>Icons\SADXModManager.ico</ApplicationIcon>
+		<PublishSingleFile>true</PublishSingleFile>
+		<SelfContained>false</SelfContained>
+		<PublishTrimmed>false</PublishTrimmed>
+		<PublishAot>false</PublishAot>
 		<Nullable>disable</Nullable>
 		<BaseOutputPath>..\bin\</BaseOutputPath>
 		<PackageReadmeFile>README.md</PackageReadmeFile>


### PR DESCRIPTION
* Updates csproj to have the publish args explicitly in the project, which is recommended by Microsoft rather than using args in the build (I recently have been updating my own NET projects to do this as well)
* Restores the action update, and goes to latest since the last PR
* Update the build scripts to remove the parameters that are now implicitly pulled from the csproj