### PR TITLE
Resolve single publish reflection bug

### DIFF
--- a/SA-Mod-Manager/Util.cs
+++ b/SA-Mod-Manager/Util.cs
@@ -788,7 +788,7 @@ namespace SAModManager
             {
                 UseShellExecute = true,
                 WorkingDirectory = Environment.CurrentDirectory,
-                FileName = Assembly.GetEntryAssembly().Location,
+                FileName = AppContext.BaseDirectory,
                 Verb = "runas" // This will prompt for admin rights
             };
 


### PR DESCRIPTION
Turns out you aren't using this method (`RequestAdminPrivileges()`), but fixing it incase the method ever gets used in the future.
I've seen this bug in my applications. It returns an empty string instead of the intended path, which then opens \Windows\System32.


Brief explanation is using `singlePublish` breaks the reflection for getting the current directory of the assembly.