### PR TITLE
Target NET 10

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,14 +37,14 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v5
       with:
-        dotnet-version: '8.0.x' 
+        dotnet-version: '10.0.x' 
 
     - name: Publish 64-bit WPF application
       working-directory: ${{env.GITHUB_WORKSPACE}}
       run: dotnet publish -r win-x64 -c Release
       
     - name: CleanUp Misc Files (64-bit)
-      working-directory: ${{github.workspace}}\bin\Release\net8.0-windows7.0\win-x64\publish
+      working-directory: ${{github.workspace}}\bin\Release\net10.0-windows7.0\win-x64\publish
       run: del SAModManager.dll.config, SAModManager.pdb
       
     - name: Publish 32-bit WPF application
@@ -52,7 +52,7 @@ jobs:
       run: dotnet publish -r win-x86 -c Release
       
     - name: CleanUp Misc Files (32-bit)
-      working-directory: ${{github.workspace}}\bin\Release\net8.0-windows7.0\win-x86\publish
+      working-directory: ${{github.workspace}}\bin\Release\net10.0-windows7.0\win-x86\publish
       run: del SAModManager.dll.config, SAModManager.pdb
 
     - name: Create Changelog (on Tag)
@@ -65,7 +65,7 @@ jobs:
       with:
         type: 'zip'
         filename: 'release_x64.zip'
-        directory: bin/Release/net8.0-windows7.0/win-x64/publish
+        directory: bin/Release/net10.0-windows7.0/win-x64/publish
         exclusions: '*.git* /*node_modules/* .editorconfig'
         
     - name: Archive 32-bit
@@ -73,7 +73,7 @@ jobs:
       with:
         type: 'zip'
         filename: 'release_x86.zip'
-        directory: bin/Release/net8.0-windows7.0/win-x86/publish
+        directory: bin/Release/net10.0-windows7.0/win-x86/publish
         exclusions: '*.git* /*node_modules/* .editorconfig'
         
       
@@ -82,6 +82,6 @@ jobs:
       with:
         body_path: ${{ env.PUBLISH_CHANGELOG_PATH }}
         files: |
-         bin/Release/net8.0-windows7.0/win-x64/publish/*.zip
-         bin/Release/net8.0-windows7.0/win-x86/publish/*.zip
+         bin/Release/net10.0-windows7.0/win-x64/publish/*.zip
+         bin/Release/net10.0-windows7.0/win-x86/publish/*.zip
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -35,14 +35,14 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: '8.0.x' 
+          dotnet-version: '10.0.x' 
 
       - name: Publish 64-bit WPF application
         working-directory: ${{env.GITHUB_WORKSPACE}}
         run: dotnet publish -r win-x64 -c ${{ matrix.configuration }}
 
       - name: CleanUp Misc Files (64-bit)
-        working-directory: ${{github.workspace}}\bin\${{ matrix.configuration }}\net8.0-windows7.0\win-x64\publish
+        working-directory: ${{github.workspace}}\bin\${{ matrix.configuration }}\net10.0-windows7.0\win-x64\publish
         run: del SAModManager.dll.config, SAModManager.pdb
 
       - name: Publish 32-bit WPF application
@@ -50,7 +50,7 @@ jobs:
         run: dotnet publish -r win-x86 -c ${{ matrix.configuration }}
 
       - name: CleanUp Misc Files (32-bit)
-        working-directory: ${{github.workspace}}\bin\${{ matrix.configuration }}\net8.0-windows7.0\win-x86\publish
+        working-directory: ${{github.workspace}}\bin\${{ matrix.configuration }}\net10.0-windows7.0\win-x86\publish
         run: del SAModManager.dll.config, SAModManager.pdb
 
       # Step to upload the dev build artifact
@@ -58,10 +58,10 @@ jobs:
         uses: actions/upload-artifact@v6
         with:
           name: SAModManager_x64_${{ matrix.configuration }}
-          path: bin/${{ matrix.configuration }}/net8.0-windows7.0/win-x64/publish
+          path: bin/${{ matrix.configuration }}/net10.0-windows7.0/win-x64/publish
 
       - name: Upload 32-bit Build Artifact
         uses: actions/upload-artifact@v6
         with:
           name: SAModManager_x86_${{ matrix.configuration }}
-          path: bin/${{ matrix.configuration }}/net8.0-windows7.0/win-x86/publish
+          path: bin/${{ matrix.configuration }}/net10.0-windows7.0/win-x86/publish

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ Version 1.3
 
 > [!NOTE]
 > To use SA Mod Manager, you must have:
-> * Windows 7 or later
-> * [.NET 8.0 x64 Desktop Runtime](https://aka.ms/dotnet-core-applaunch?missing_runtime=true&arch=x64&apphost_version=8.0.0&gui=true)
+> * Windows 10 or later
+> * [.NET 10.0 x64 Desktop Runtime](https://aka.ms/dotnet-core-applaunch?missing_runtime=true&arch=x64&apphost_version=10.0.0&gui=true)
 
 > [!IMPORTANT]
 > To use the Mod Loader, you must have:

--- a/SA-Mod-Manager/SAModManager.csproj
+++ b/SA-Mod-Manager/SAModManager.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>WinExe</OutputType>
-		<TargetFramework>net8.0-windows7.0</TargetFramework>
+		<TargetFramework>net10.0-windows7.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<UseWPF>true</UseWPF>
 		<UseWindowsForms>true</UseWindowsForms>
@@ -95,8 +95,6 @@
 			</PackageReference>
 		<PackageReference Include="SharpCompress" Version="0.49.1" />
 		<PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
-		<PackageReference Include="System.Net.Http" Version="4.3.4" />
-		<PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Update the app to build with NET 10; including updating the CI runners.
NET 8 goes EOL on November 10, 2026

* Tested on Windows 10 22H2
* Tested on Windows 11 24H2+
* Tested with Proton 11.0 (Stable)
* For clean migration, opened this https://github.com/X-Hax/SA-Mod-Manager/pull/403 ✅ 
* Dropped Windows 7 from the README, since NET 10 is not supported without hacking NET 10 (this was technically true with NET 8 as well)

<details>
  <summary>Old description</summary>
If we want a clean update migration, need to update the 'Net8Missing' and re-activate the `Net8Check` (but update it for Net 10), then release one last NET 8 build.
Otherwise, on Windows at least, users will get the Desktop Runtime popup (handled by the program) and directed to the download page. If that's not a concern, its fine to skip the check and last NET 8 release.

~~Note: SharpCompress requires signature migration: `SevenZipArchive.Open -> SevenZipArchive.OpenArchive`
Confirmed adding archive manually and updating over the air working expected with the migration.~~ Handled in fb1c3570f2d4067698d7d01c583d4964632f8aa5
</details>